### PR TITLE
[TASK] allow installation in TYPO3 10.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "homepage": "https://github.com/bmoex/my_configurable_routes",
     "license": "LGPL-3.0+",
     "require": {
-        "typo3/cms-core": ">=9.5.0 <10.0.0",
-        "typo3/cms-frontend": ">9.5.0 <10.0.0"
+        "typo3/cms-core": "^9.5.0 || ^10.4.0",
+        "typo3/cms-frontend": "^9.5.0 || ^10.4.0"
     },
 
     "autoload": {


### PR DESCRIPTION
The extension seems to work just fine with TYPO3 10.4, at least with my current project the setup worked like documented.